### PR TITLE
fix strict type comparison

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ export default function contributin ({
       .json({ msg: "No username provided" });
     }
 
-    if (coc && "1" !== req.body.coc) {
+    if (coc && 1 !== req.body.coc) {
       return res
       .status(400)
       .json({ msg: "Agreement to CoC is mandatory" });


### PR DESCRIPTION
when using `===` we actually send `1` and not `"1"`

fixes #7 
